### PR TITLE
[lems-a3/lems#79] Modify LC padding bytes for SC App usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(APP_SRC_FILES
   fsw/src/lc_utils.c
 )
 
+include_directories(${APPLICATION_PLATFORM_INC_LIST})
+
 # Create the app module
 add_cfe_app(lc ${APP_SRC_FILES})
 

--- a/fsw/inc/lc_msg.h
+++ b/fsw/inc/lc_msg.h
@@ -157,6 +157,7 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command Header */
 
     uint16 RTSId; /**< \brief RTS Id to start */
+    uint16 Padding; /**< \brief Structure padding */
 } LC_RTSRequest_t;
 
 /**\}*/


### PR DESCRIPTION
 - Fixed Padding mismatch for LC to send commands to SC on AP trigger
 - Added nos3 line to include appropriate inc files
 
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/LC/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fix LC to SC command padding
- The SC app appears to have added additional padding to the command struct for x64 architectures. The extra padding causes commands from LC to SC to fail on length mismatch.

**Testing performed**
Steps taken to test the contribution:
1. Build as normal
2. Defined a WP and AP to trigger any RTS
3. Previously, when AP triggered SC app gave mismatch length error
4. Now, AP triggers successfully trigger SC RTS

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - Behavior Change: Enabled successful RTS start via LC
 -
**System(s) tested on**
 - Ubuntu VM

**Contributor Info - All information REQUIRED for consideration of pull request**
D. Cody Cutright, NASA IV&V
 - Note CLA's apply to software contributions.
